### PR TITLE
Fix link to HTML file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Perl 6, the musical. Material for learning Perl 6 from scratch. 
 
-You can check out the [work in progress in this document](perl6.html).
+You can check out the [work in progress in this document](https://github.com/JJ/perl6em/blob/master/docs/perl6.html).


### PR DESCRIPTION
JJ, I guess you mean `https://github.com/JJ/perl6em/blob/master/docs/perl6.html` (`docs/` is missing).

Even better, you can now [set up GitHub Pages](https://github.com/JJ/perl6em/settings) to serve proper HTML with the right MIME type from any branch, including `master`. This file would be visible at `https://JJ.github.io/perl6em/docs/perl6.html`.