### PR TITLE
Update URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Perl 6, the musical. Material for learning Perl 6 from scratch. 
 
-You can check out the [work in progress in this document](https://github.com/JJ/perl6em/blob/master/docs/perl6.html).
+You can check out the [work in progress in this document](https://jj.github.io/perl6em/perl6.html).


### PR DESCRIPTION
The README still points to [`https://github.com/JJ/perl6em/blob/master/docs/perl6.html`](https://github.com/JJ/perl6em/blob/master/docs/perl6.html), JJ.

(You may want to put `https://jj.github.io/perl6em/perl6.html` as the website of the project too, at the top of the main page of the repo.)