### PR TITLE
Load MathJax from CDN using same protocol

### DIFF
--- a/docs/perl6.html
+++ b/docs/perl6.html
@@ -246,7 +246,7 @@ for the JavaScript code in this tag.
 });
 </script>
 <script type="text/javascript"
-        src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>
+        src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>
 </head>
 <body>
 <div id="content">


### PR DESCRIPTION
When loading the document [over HTTPS](https://jj.github.io/perl6em/perl6.html) (as one should), there's a &ldquo;mixed content&rdquo; error that prevents MathJax from being loaded. This solves the issue.