### PR TITLE
changes required to get a pdf output using 'md2pdf-kdp':

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,17 @@ also [a play](https://github.com/JJ/perl6em/releases), which was
 [featured in The New Stack](https://thenewstack.io/cs-professor-tries-teaching-family-perl-6/) after
 stating it at the Perl devroom in FOSDEM.
 
+## Building the book
 
+### Requirements
 
+Perl 6 modules required:
+
++ Text::Markdown;
++ Text::Wrap;
++ JSON::Tiny;
+
+On a Debian 8 system the following packages may be required (if not
+already installed):
+
++ texlive-xetex

--- a/md2pdf-kdp
+++ b/md2pdf-kdp
@@ -2,7 +2,8 @@
 
 # Cambia la plantilla de latex al directorio donde esté
 utils/deploy-file.p6 txt utils/urls-with-short.json
-pandoc --template=/home/jmerelo/Libros/perl6em/utils/plantilla-kdp.latex \
+#pandoc --template=/home/jmerelo/Libros/perl6em/utils/plantilla-kdp.latex \
+pandoc --template=./utils/plantilla-kdp.latex \
     -V language=english -V lang=english \
     -V author='JJ Merelo' -V title='Learning Perl 6'\
     -V documentclass=book\
@@ -12,4 +13,3 @@ pandoc --template=/home/jmerelo/Libros/perl6em/utils/plantilla-kdp.latex \
     txt/0-intro-deploy.md txt/1-liners-deploy.md --toc
 
 rm txt/*-deploy.md
-

--- a/utils/deploy-file.p6
+++ b/utils/deploy-file.p6
@@ -31,12 +31,13 @@ sub MAIN( $dir = "txt/", $urls-file="urls-with-short.json" ) {
 		my @lines = $i.text.split("\n");
 		for @lines -> $l {
 		    if ( $l.chars > 60 ) {
-			my $wrapped=wrap-text($l,:width(60),:postfix('\\'),:prefix("      "));
+			#my $wrapped=wrap-text($l,:width(60),:postfix('\\'),:prefix("      "));
+			my $wrapped=wrap-text($l,:width(60),:prefix("      "));
 			$text .= subst(/$l/,$wrapped);
 		    }
 		}
 	    }
-		
+
 	}
 	my ($basename) = ($f ~~ /(.+)\.md/);
 	spurt $basename[0] ~ "-deploy.md", $text;


### PR DESCRIPTION
+ used a relative path for the template location

+ modified the deployment script to remove an unknown arg in a module
  subroutine

other changes:

+ noted requirements for Perl 6 modules and Debian 8 packages